### PR TITLE
Remove unneeded files field in package.json

### DIFF
--- a/.changeset/tender-pans-juggle.md
+++ b/.changeset/tender-pans-juggle.md
@@ -1,0 +1,5 @@
+---
+"@apollo/graphql-testing-library": patch
+---
+
+Fix bundling issue caused by an unneeded files field in package.json, and adjust relative file paths.

--- a/package.json
+++ b/package.json
@@ -14,20 +14,17 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "dist"
-  ],
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./index.cjs",
+  "module": "./index.js",
   "exports": {
     "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+      "types": "./index.d.cts",
+      "default": "./index.cjs"
     },
     "default": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "types": "./index.d.ts",
+      "default": "./index.js"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
If we were publishing from the root `package.json`, `files` would make sense here, but since we're copying files into `dist`, using an `.npmignore` and then running npm publish from inside `dist`, the `files` field was a bug. Removed and fixed relative file paths, testing via `npm pack` locally.