### PR TITLE
Replace Discord with Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
   <p>Generate Mock Service Worker handlers for your GraphQL APIs.</p>
 
-[![npm version](https://badge.fury.io/js/%40apollo%2Fgraphql-testing-library.svg)](https://badge.fury.io/js/%40apollo%2Fgraphql-testing-library) ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/alessbell/3fd56e82b55e134ee9cf57f28b0b3d49/raw/jest-coverage-comment__main.json) ![workflow](https://github.com/apollographql/graphql-testing-library/actions/workflows/test.yml/badge.svg) [![Join our Discord server](https://img.shields.io/discord/1022972389463687228.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square)](https://discord.gg/graphos)
+[![npm version](https://badge.fury.io/js/%40apollo%2Fgraphql-testing-library.svg)](https://badge.fury.io/js/%40apollo%2Fgraphql-testing-library) ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/alessbell/3fd56e82b55e134ee9cf57f28b0b3d49/raw/jest-coverage-comment__main.json) ![workflow](https://github.com/apollographql/graphql-testing-library/actions/workflows/test.yml/badge.svg)
 
 </div>
 <hr />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" data-test>
   <a href="https://graphql.org/">
     <img width="150" height="150" src="https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg">
   </a>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,8 +7,7 @@ export default defineConfig({
     starlight({
       title: "GraphQL Testing Library",
       social: {
-        github: "https://github.com/apollographql/graphql-testing-library",
-        discord: "https://discord.gg/graphos",
+        github: "https://github.com/apollographql/graphql-testing-library"
       },
       sidebar: [
         {


### PR DESCRIPTION
Remove Discord links since the Discourse Community Forum there is becoming our focus.